### PR TITLE
Expose release option to publish subcommand

### DIFF
--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -4,11 +4,14 @@ var module = require('../index.js');
 var program = require('commander');
 
 program
-  .command('publish')
+  .command('publish [options]')
   .description('publish the contents of .\\bin\\stage to the current version\'s GitHub release')
-  .action(function() {
+  .option("-r, --release", "publish immediately, do not create draft")
+  .action(function(cmd, options){
+    var opts = {};
+    opts.draft = options.release ? false : true;
     var x = new module();
-    x.publish();
+    x.publish(opts);
   });
 
 program

--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -4,20 +4,20 @@ var module = require('../index.js');
 var program = require('commander');
 
 program
-	.command('publish')
-	.description('publish the contents of .\\bin\\stage to the current version\'s GitHub release')
-	.action(function() {
-		var x = new module();
-		x.publish();
-	});
+  .command('publish')
+  .description('publish the contents of .\\bin\\stage to the current version\'s GitHub release')
+  .action(function() {
+    var x = new module();
+    x.publish();
+  });
 
 program
-	.command('help','',{isDefault: true, noHelp: true})
-	.action(function() {
-		console.log();
-		console.log('Usage: node-pre-gyp-github publish');
-		console.log();
-		console.log('publish the contents of .\\bin\\stage to the current version\'s GitHub release');
-	});
+  .command('help','',{isDefault: true, noHelp: true})
+  .action(function() {
+    console.log();
+    console.log('Usage: node-pre-gyp-github publish');
+    console.log();
+    console.log('publish the contents of .\\bin\\stage to the current version\'s GitHub release');
+  });
 
 program.parse(process.argv);

--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -21,3 +21,5 @@ program
   });
 
 program.parse(process.argv);
+
+if (!program.args.length) program.help();

--- a/index.js
+++ b/index.js
@@ -56,9 +56,10 @@ NodePreGypGithub.prototype.authenticate_settings = function(){
 	};
 };
 
-NodePreGypGithub.prototype.createRelease = function(callback) {
+NodePreGypGithub.prototype.createRelease = function(options, callback) {
 	this.github.authenticate(this.authenticate_settings());
-	this.github.releases.createRelease({
+
+	var _options = {
 		'owner': this.owner,
 		'repo': this.repo,
 		'tag_name': this.package_json.version,
@@ -67,7 +68,18 @@ NodePreGypGithub.prototype.createRelease = function(callback) {
 		'body': this.package_json.name + ' ' + this.package_json.version,
 		'draft': true,
 		'prerelease': false
-	}, callback);
+	}
+
+  opts.owner = options.owner || _options.owner;
+  opts.repo = options.repo || _options.repo;
+  opts.tag_name = options.tag_name || _options.tag_name;
+  opts.target_commitish = options.target_commitish || _options.target_commitish;
+  opts.name = options.name || _options.name;
+  opts.body = options.body || _options.body;
+  opts.draft = options.draft || _options.draft;
+  opts.prerelease = options.prerelease || _options.prerelease;
+
+	this.github.releases.createRelease(options, callback);
 };
 
 NodePreGypGithub.prototype.uploadAsset = function(cfg){
@@ -107,7 +119,7 @@ NodePreGypGithub.prototype.uploadAssets = function(){
 	}.bind(this));
 };
 
-NodePreGypGithub.prototype.publish = function() {
+NodePreGypGithub.prototype.publish = function(options) {
 	this.init();
 	this.github.authenticate(this.authenticate_settings());
 	this.github.releases.listReleases({
@@ -128,7 +140,7 @@ NodePreGypGithub.prototype.publish = function() {
 		this.release = release[0];
 		
 		if(!release.length) {
-			this.createRelease(function(err, release) {
+			this.createRelease(options, function(err, release) {
 				this.release = release;
 				console.log('Release ' + this.package_json.version + " not found, so a draft release was created. YOU MUST MANUALLY PUBLISH THIS DRAFT WITHIN GITHUB FOR IT TO BE ACCESSIBLE.");
 				this.uploadAssets();


### PR DESCRIPTION
We use a CI server to release, and if the release isn't publish node-pre-gyp-github doesnt appear to be able to find the current release and add binaries to it.

My solution was to just hardcode draft:false which has been working for us but wed like to upstream, see https://github.com/voodootikigod/node-serialport/issues/644

Ive broken them out maintaining the defaults, and added the -r option to the publish subcommand which sets draft:false.

Could use a good test yet.
Thoughts? 