### PR TITLE
fix overriding options

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,9 +69,11 @@ NodePreGypGithub.prototype.createRelease = function(args, callback) {
 	};
 	
 	Object.keys(args).forEach(function(key) {
-		options[key] = args[key] || options[key];
+		if(args.hasOwnProperty(key)) {
+			options[key] = args[key];
+		}
 	});
-	
+		
 	this.github.authenticate(this.authenticate_settings());
 	this.github.releases.createRelease(options, callback);
 };


### PR DESCRIPTION
Since draft is false, it previously never overrode the default. Check instead for key existence. 