### PR TITLE
No more dual version in package.json and --tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Within GitHub, create a new authorization:
 1. go to Settings 
 2. click Personal access tokens
 3. click Generate new token
-4. Select all checkboxes (in a future update I will specify which precise checkboxes are needed, but for now...)
+4. Select "public_repo" and "repo_deployment"
 5. Generate Token
 6. copy the key that's generated and set NODE_PRE_GYP_GITHUB_TOKEN environment variable to it. Within your command prompt:
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ npm install -g node-pre-gyp-github
 ```
 
 ## Configuration
-This module is intended to be used with node-pre-gyp. Therefore, be sure to configure and install node-pre-gyp first. After having done that, within **```package.json```** update the ```binary``` property ```host``` so it matches the following format:
+This module is intended to be used with node-pre-gyp. Therefore, be sure to configure and install node-pre-gyp first. After having done that, within **```package.json```** update the ```binary``` properties ```host``` and ```remote_path``` so it matches the following format:
 
 ```
-https://github.com/{owner}/{repo}/releases/download/{1.0.1}
+  "host": "https://github.com/[owner]/[repo]/releases/download/",
+  "remote_path": "{version}"
 ```
-Be sure to replace ```{owner}```, ```{repo}```, ```{1.0.1}``` with actual values.
 
-***WARNING: Variable substitutions are not supported on the ```host``` property so you will have to manually update the version number with every change.*** Failure to do so will result in users installing the wrong binary versions.
+Be sure to replace ```[owner]```, ```[repo]```, with actual values,
+but DO NOT replace ```{version}``` with actual version.
 
-**Tip:** Since the version number will be included within the ```host``` you can ommit it from the package name.
+***WARNING: Variable substitutions are not supported on the ```host``` property but are supported in ```remote_path```, but the value of ```remote_path``` after substitutions must match the release tag name.*** Otherwise it will result in users installing the wrong binary versions.
 
 Within GitHub, create a new authorization:
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,21 @@ SET NODE_PRE_GYP_GITHUB_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 2. node-pre-gyp build
 3. node-pre-gyp package
 4. node-pre-gyp-github publish --release
+
+## Advanced - release tag name
+
+```node-pre-gyp-github``` will match the current release tag with the contents of the ```version``` property found in ```package.json```. Using --tag option you may supply your own tag name, but make sure the ```remote_path``` property matches the tag name exactly (after substitutions). Otherwise ```node-pre-gyp-github`` will not be able to upload packed binary.
+
+Let's say the new version of your package is 1.2.3 and you want release tag to match the default ```npm version``` format (with "v" prefix):
+
+Change ```remote_path``` to:
+
+```
+  "remote_path": "v{version}"
+```
+
+and publish with:
+
+```
+node-pre-gyp-github publish --release --tag v1.2.3
+```

--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -7,9 +7,11 @@ program
 	.command('publish [options]')
 	.description('publish the contents of .\\bin\\stage to the current version\'s GitHub release')
 	.option("-r, --release", "publish immediately, do not create draft")
+	.option("-t, --tag", "release tag name")
 	.action(function(cmd, options){
 		var opts = {},
 			x = new module();
+		if (options.tag) opts.tag_name = options.tag;
 		opts.draft = options.release ? false : true;
 		x.publish(opts);
 	});

--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -2,12 +2,11 @@
 
 var module = require('../index.js');
 var program = require('commander');
-
 program
 	.command('publish [options]')
 	.description('publish the contents of .\\bin\\stage to the current version\'s GitHub release')
 	.option("-r, --release", "publish immediately, do not create draft")
-	.option("-t, --tag", "release tag name")
+	.option("-t, --tag <name>", "release tag name")
 	.action(function(cmd, options){
 		var opts = {},
 			x = new module();

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ NodePreGypGithub.prototype.uploadAsset = function(cfg){
 		filePath: cfg.filePath
 	}, function(err){
 		if(err) {console.error(err); return;}
-		console.log('Staged file ' + cfg.fileName + ' saved to ' + this.owner + '/' +  this.repo + ' release ' + this.package_json.version + ' successfully.');
+		console.log('Staged file ' + cfg.fileName + ' saved to ' + this.owner + '/' +  this.repo + ' release ' + this.release.tag_name + ' successfully.');
 	}.bind(this));
 };
 
@@ -102,7 +102,7 @@ NodePreGypGithub.prototype.uploadAssets = function(){
 				return element.name === file;
 			});
 			if(asset.length) {
-				console.log("Staged file " + file + " found but it already exists in release " + this.package_json.version + ". If you would like to replace it, you must first manually delete it within GitHub.");
+				console.log("Staged file " + file + " found but it already exists in release " + this.release.tag_name + ". If you would like to replace it, you must first manually delete it within GitHub.");
 			}
 			else {
 				console.log("Staged file " + file + " found. Proceeding to upload it.");
@@ -127,8 +127,9 @@ NodePreGypGithub.prototype.publish = function(options) {
 		if(err) {console.error(err); return;}
 		
 		release	= (function(){ // create a new array containing only those who have a matching version.
+			var tag_name = options.tag_name || this.package_json.version;
 			data = data.filter(function(element, index, array){
-				return element.tag_name === this.package_json.version;
+				return element.tag_name === tag_name;
 			}.bind(this));
 			return data;
 		}.bind(this))();
@@ -138,7 +139,7 @@ NodePreGypGithub.prototype.publish = function(options) {
 		if(!release.length) {
 			this.createRelease(options, function(err, release) {
 				this.release = release;
-				console.log('Release ' + this.package_json.version + " not found, so a draft release was created. YOU MUST MANUALLY PUBLISH THIS DRAFT WITHIN GITHUB FOR IT TO BE ACCESSIBLE.");
+				console.log('Release ' + release.tag_name + " not found, so a draft release was created. YOU MUST MANUALLY PUBLISH THIS DRAFT WITHIN GITHUB FOR IT TO BE ACCESSIBLE.");
 				this.uploadAssets();
 			}.bind(this));
 		}

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ NodePreGypGithub.prototype.uploadAssets = function(){
 				console.log("Staged file " + file + " found. Proceeding to upload it.");
 				this.uploadAsset({
 					fileName: file,
-					filePath: path.join(this.stage_dir, file)
+					filePath: path.join(stage_dir, file)
 				});
 			}
 		}.bind(this));

--- a/index.js
+++ b/index.js
@@ -93,9 +93,9 @@ NodePreGypGithub.prototype.uploadAsset = function(cfg){
 };
 
 NodePreGypGithub.prototype.uploadAssets = function(){
-	var asset;
-	console.log("Stage directory path: " + path.join(this.stage_dir));
-	fs.readdir(path.join(this.stage_dir), function(err, files){
+	var asset, stage_dir = path.join(this.stage_dir, this.release.tag_name);
+	console.log("Stage directory path: " + stage_dir);
+	fs.readdir(stage_dir, function(err, files){
 		if(typeof files === 'undefined') {console.log('no files found'); return;}
 		files.forEach(function(file){
 			asset = this.release.assets.filter(function(element, index, array){


### PR DESCRIPTION
Based on #10

First of all it's ***backward incompatible*** due to use of "host" + "remote_path" instead of sole "host".
People will have to change this one thing in their `package.json` (but only ***once*** versus ***always maintaining second version tag***).

The idea behind this patch is to facilitate "remote_path" property understood by node-pre-gyp which supports variable substitution. But then the node-pre-gyp will package under the `"{stage_dir}/{remote_path}"` so I had to modify file search path in `uploadAssets`.

I also added the custom --tag option along with the readme update.

Additionally I've ensured that the only access for the token you need is `public_repo` and `repo_deployment`.