### PR TITLE
Remote path support with {version} placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This module is intended to be used with node-pre-gyp. Therefore, be sure to conf
 Be sure to replace ```[owner]```, ```[repo]```, with actual values,
 but DO NOT replace ```{version}``` with actual version.
 
-***WARNING: Variable substitutions are not supported on the ```host``` property and in the ```remote_path``` only `{version}` placeholder is supported. The value of ```remote_path``` will become a release tag name.***
+***WARNING: Variable substitutions are not supported on the ```host``` property and on the ```remote_path``` only ```{version}``` placeholder is supported. The value of ```remote_path``` after substitution will become a release tag name. Do not use [forbidden git tag characters](https://git-scm.com/docs/git-check-ref-format) for ```version``` and ```remote_path``` properties.***
 
 Within GitHub, create a new authorization:
 

--- a/README.md
+++ b/README.md
@@ -17,23 +17,24 @@ npm install -g node-pre-gyp-github
 ```
 
 ## Configuration
-This module is intended to be used with node-pre-gyp. Therefore, be sure to configure and install node-pre-gyp first. After having done that, within **```package.json```** update the ```binary``` property ```host``` so it matches the following format:
+This module is intended to be used with node-pre-gyp. Therefore, be sure to configure and install node-pre-gyp first. After having done that, within **```package.json```** update the ```binary``` properties ```host``` and ```remote_path``` so it matches the following format:
 
 ```
-https://github.com/{owner}/{repo}/releases/download/{1.0.1}
+  "host": "https://github.com/[owner]/[repo]/releases/download/",
+  "remote_path": "{version}"
 ```
-Be sure to replace ```{owner}```, ```{repo}```, ```{1.0.1}``` with actual values.
 
-***WARNING: Variable substitutions are not supported on the ```host``` property so you will have to manually update the version number with every change.*** Failure to do so will result in users installing the wrong binary versions.
+Be sure to replace ```[owner]```, ```[repo]```, with actual values,
+but DO NOT replace ```{version}``` with actual version.
 
-**Tip:** Since the version number will be included within the ```host``` you can ommit it from the package name.
+***WARNING: Variable substitutions are not supported on the ```host``` property and in the ```remote_path``` only `{version}` placeholder is supported. The value of ```remote_path``` will become a release tag name.***
 
 Within GitHub, create a new authorization:
 
 1. go to Settings 
 2. click Personal access tokens
 3. click Generate new token
-4. Select all checkboxes (in a future update I will specify which precise checkboxes are needed, but for now...)
+4. Select "public_repo" and "repo_deployment"
 5. Generate Token
 6. copy the key that's generated and set NODE_PRE_GYP_GITHUB_TOKEN environment variable to it. Within your command prompt:
 

--- a/index.js
+++ b/index.js
@@ -163,6 +163,8 @@ NodePreGypGithub.prototype.publish = function(options) {
 		
 		if(!release.length) {
 			this.createRelease(options, function(err, release) {
+				if(err) {console.error(err); return;}
+
 				this.release = release;
 				console.log('Release ' + this.package_json.version + " not found, so a draft release was created. YOU MUST MANUALLY PUBLISH THIS DRAFT WITHIN GITHUB FOR IT TO BE ACCESSIBLE.");
 				this.uploadAssets();

--- a/index.js
+++ b/index.js
@@ -166,7 +166,11 @@ NodePreGypGithub.prototype.publish = function(options) {
 				if(err) {console.error(err); return;}
 
 				this.release = release;
-				console.log('Release ' + this.package_json.version + " not found, so a draft release was created. YOU MUST MANUALLY PUBLISH THIS DRAFT WITHIN GITHUB FOR IT TO BE ACCESSIBLE.");
+				if (release.draft) {
+					console.log('Release ' + release.tag_name + " not found, so a draft release was created. YOU MUST MANUALLY PUBLISH THIS DRAFT WITHIN GITHUB FOR IT TO BE ACCESSIBLE.");
+				} else {
+					console.log('Release ' + release.tag_name + " not found, so a new release was created and published.");
+				}
 				this.uploadAssets();
 			}.bind(this));
 		}

--- a/index.js
+++ b/index.js
@@ -126,9 +126,17 @@ NodePreGypGithub.prototype.publish = function(options) {
 		
 		if(err) {console.error(err); return;}
 		
+		// when remote_path is set expect files to be in stage_dir / remote_path after substitution
+		if (this.package_json.binary.remote_path) {
+			options.tag_name = this.package_json.binary.remote_path.replace(/{version}/g, this.package_json.version);
+			this.stage_dir = path.join(this.stage_dir, options.tag_name);
+		} else {
+			options.tag_name = this.package_json.version;
+		}
+		
 		release	= (function(){ // create a new array containing only those who have a matching version.
 			data = data.filter(function(element, index, array){
-				return element.tag_name === this.package_json.version;
+				return element.tag_name === options.tag_name;
 			}.bind(this));
 			return data;
 		}.bind(this))();

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ NodePreGypGithub.prototype.uploadAsset = function(cfg){
 		filePath: cfg.filePath
 	}, function(err){
 		if(err) {console.error(err); return;}
-		console.log('Staged file ' + cfg.fileName + ' saved to ' + this.owner + '/' +  this.repo + ' release ' + this.package_json.version + ' successfully.');
+		console.log('Staged file ' + cfg.fileName + ' saved to ' + this.owner + '/' +  this.repo + ' release ' + this.release.tag_name + ' successfully.');
 	}.bind(this));
 };
 
@@ -102,7 +102,7 @@ NodePreGypGithub.prototype.uploadAssets = function(){
 				return element.name === file;
 			});
 			if(asset.length) {
-				console.log("Staged file " + file + " found but it already exists in release " + this.package_json.version + ". If you would like to replace it, you must first manually delete it within GitHub.");
+				console.log("Staged file " + file + " found but it already exists in release " + this.release.tag_name + ". If you would like to replace it, you must first manually delete it within GitHub.");
 			}
 			else {
 				console.log("Staged file " + file + " found. Proceeding to upload it.");


### PR DESCRIPTION
Another approach to #11.

Add support of ```remote_path``` with ```{version}``` placeholder as release tag names instead of tag names hardcoded into ```host```.

This solution is backward compatible, so if no ```remote_path``` then use ```version``` as a release tag name.

To look for packages ```remote_path``` is appended to ```stage_dir``` if set.

Adds missing error message and configuration sanity checking.

I was fiddling around a little bit with github releases and can confirm that slashes "/" within ```remote_path``` are perfectly safe and work. The package gets uploaded, the tag name is created and you can access the binary by that path name.

Only git tag unsupported characters are not allowed. Github will nicely handle that throwing errors when publishing with --release. If publishing without --release the draft will be created but github will not allow you to publish with broken tag name.