### PR TITLE
Consistent Error Handling and minor bug fixes

### DIFF
--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -5,7 +5,7 @@ var program = require('commander');
 
 program
 	.command('publish [options]')
-	.description('publish the contents of .\\bin\\stage to the current version\'s GitHub release')
+	.description('publishes the contents of .\\build\\stage\\{version} to the current version\'s GitHub release')
 	.option("-r, --release", "publish immediately, do not create draft")
 	.action(function(cmd, options){
 		var opts = {},
@@ -20,7 +20,7 @@ program
 		console.log();
 		console.log('Usage: node-pre-gyp-github publish');
 		console.log();
-		console.log('publish the contents of .\\bin\\stage to the current version\'s GitHub release');
+		console.log('publishes the contents of .\\build\\stage\\{version} to the current version\'s GitHub release');
 	});
 
 program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-pre-gyp-github",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A node-pre-gyp module which provides the ability to publish to GitHub releases.",
   "bin": "./bin/node-pre-gyp-github.js",
   "main": "index.js",


### PR DESCRIPTION
**Changes:**

* made error handling more consistent and always exit with a non 0 error code. https://github.com/bchr02/node-pre-gyp-github/issues/13
* an error will now occur if NODE_PRE_GYP_GITHUB_TOKEN is not found.
* slightly changed some of the error messages and removed some of the prepended "Error: ". They are no longer needed since were are now throwing errors.
* fixed a bug that caused an error to not occur when binary files were not found in the stage directory.
* added a missing error catch for readdir that caused an error to not occur if the stage directory was missing.
* in bin/node-pre-gyp-github.js, corrected the path that was displayed in the help text.