### PR TITLE
100% test coverage, new silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # node-pre-gyp-github
 ##### A node-pre-gyp module which provides the ability to publish to GitHub releases.
 
+[![Coverage Status](https://coveralls.io/repos/github/bchr02/node-pre-gyp-github/badge.svg?branch=master)](https://coveralls.io/github/bchr02/node-pre-gyp-github?branch=master)
 [![Join the chat at https://gitter.im/bchr02/node-pre-gyp-github](https://badges.gitter.im/bchr02/node-pre-gyp-github.svg)](https://gitter.im/bchr02/node-pre-gyp-github?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Usage
 Instead of ```node-pre-gyp publish``` use **```node-pre-gyp-github publish```**
 
-## Options
+## Options for publish command
+* --silent : Turns verbose messages off.
 * --release : Publish the GitHub Release immediately instead of creating a Draft.
 
-ex. ```node-pre-gyp-github publish --release```
+  For Ex. ```node-pre-gyp-github publish --release```
 
 ## Install
 ```javascript

--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -7,10 +7,12 @@ program
 	.command('publish [options]')
 	.description('publishes the contents of .\\build\\stage\\{version} to the current version\'s GitHub release')
 	.option("-r, --release", "publish immediately, do not create draft")
+	.option("-s, --silent", "turns verbose messages off")
 	.action(function(cmd, options){
 		var opts = {},
 			x = new module();
 		opts.draft = options.release ? false : true;
+		opts.verbose = options.silent ? false : true;
 		x.publish(opts);
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "node-pre-gyp-github",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A node-pre-gyp module which provides the ability to publish to GitHub releases.",
   "bin": "./bin/node-pre-gyp-github.js",
   "main": "index.js",
   "scripts": {
     "test": "mocha test",
-	"coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec"
+    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report text-lcov -- -R spec | node ./node_modules/coveralls/bin/coveralls.js"
   },
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "coveralls": "^2.11.9",
     "istanbul": "^0.4.3",
     "mocha": "^2.5.3"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ var reset_index = function(index_string_ref) {
 	return require(index_string_ref);
 };
 var reset_mocks = function() {
-	process.env['NODE_PRE_GYP_GITHUB_TOKEN'] = "secret";
+	process.env.NODE_PRE_GYP_GITHUB_TOKEN = "secret";
 	fs = reset_index('fs');
 	fs.readFileSync = function(){return '{"name":"test","version":"0.0.1","repository": {"url":"git+https://github.com/test/test.git"},"binary":{"host":"https://github.com/test/test/releases/download/","remote_path":"{version}"}}';};
 	index.stage_dir = stage_dir;
@@ -19,54 +19,89 @@ var reset_mocks = function() {
 		cb(null, [{"tag_name":"0.0.0","assets":[{"name":"filename"}]}]);
 	};
 	index.github.releases.createRelease = function(options, cb){
-		cb(null,{"tag_name":"0.0.1","assets":[{}]});
+		cb(null,{"tag_name":"0.0.1","draft":true,"assets":[{}]});
 	};
 	index.github.releases.uploadAsset = function(cfg,cb){cb();};
 };
 
+if(!process.env.COVERALLS_SERVICE_NAME) console.log('To post to coveralls.io, be sure to set COVERALLS_SERVICE_NAME environment variable');
+if(!process.env.COVERALLS_REPO_TOKEN) console.log('To post to coveralls.io, be sure to set COVERALLS_REPO_TOKEN environment variable');
+
 describe("Publishes packages to GitHub Releases", function() {
-	describe("Throws an Error when node-pre-gyp-github is not configured properly", function() {
+	
+	describe("Publishes without an error under all options", function() {
+		
+		it("should publish a non-draft release without an error", function() {
+			var options = {'draft': false, 'verbose': false};
+			reset_mocks();
+			fs.readdir = function(filename, cb) {
+				cb(null,["filename"]);
+			};
+			index.github.releases.createRelease = function(options, cb){
+				cb(null,{"tag_name":"0.0.1","draft":false,"assets":[{}]});
+			};
+			expect(function(){ index.publish(options); }).to.not.throw();
+		});
+		
+		it("should publish a draft release without an error", function() {
+			var options = {'draft': true, 'verbose': false};
+			reset_mocks();
+			fs.readdir = function(filename, cb) {
+				cb(null,["filename"]);
+			};
+			expect(function(){ index.publish(options); }).to.not.throw();
+		});
+	
+	});
+	
+	describe("Throws an error when node-pre-gyp-github is not configured properly", function() {
 		
 		it("should throw an error when missing repository.url in package.json", function() {
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readFileSync = function(){return '{}';};
-			expect(function(){ index.publish(); }).to.throw("Missing repository.url in package.json");
+			expect(function(){ index.publish(options); }).to.throw("Missing repository.url in package.json");
 		});
 		
 		it("should throw an error when a correctly formatted GitHub repository.url is not found in package.json", function() {
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readFileSync = function(){return '{"repository": {"url":"bad_format_url"}}';};
-			expect(function(){ index.publish(); }).to.throw("A correctly formatted GitHub repository.url was not found within package.json");
+			expect(function(){ index.publish(options); }).to.throw("A correctly formatted GitHub repository.url was not found within package.json");
 		});
 		
 		it("should throw an error when missing binary.host in package.json", function() {
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readFileSync = function(){return '{"repository": {"url":"git+https://github.com/test/test.git"}}';};
-			expect(function(){ index.publish(); }).to.throw("Missing binary.host in package.json");
+			expect(function(){ index.publish(options); }).to.throw("Missing binary.host in package.json");
 		});
 		
 		it("should throw an error when binary.host does not begin with the correct url", function() {
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readFileSync = function(){return '{"repository": {"url":"git+https://github.com/test/test.git"},"binary":{"host":"bad_format_binary"}}';};
-			expect(function(){ index.publish(); }).to.throw(/^binary.host in package.json should begin with:/i);
+			expect(function(){ index.publish(options); }).to.throw(/^binary.host in package.json should begin with:/i);
 		});
 		
 		it("should throw an error when the NODE_PRE_GYP_GITHUB_TOKEN environment variable is not found", function() {
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
-			process.env['NODE_PRE_GYP_GITHUB_TOKEN'] = "";
-			expect(function(){ index.publish(); }).to.throw("NODE_PRE_GYP_GITHUB_TOKEN environment variable not found");
+			process.env.NODE_PRE_GYP_GITHUB_TOKEN = "";
+			expect(function(){ index.publish(options); }).to.throw("NODE_PRE_GYP_GITHUB_TOKEN environment variable not found");
 		});
 		
 		it("should throw an error when github.releases.listReleases returns an error", function() {
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			index.github.releases.listReleases = function(options, cb){
 				cb(new Error('listReleases error'));
 			};
-			expect(function(){ index.publish(); }).to.throw('listReleases error');
+			expect(function(){ index.publish(options); }).to.throw('listReleases error');
 		});
 		
 		it("should throw an error when github.releases.createRelease returns an error", function() {
-			var options = {'draft': true};
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			index.github.releases.listReleases = function(options, cb){
 				cb(null,null);
@@ -78,7 +113,7 @@ describe("Publishes packages to GitHub Releases", function() {
 		});
 		
 		it("should throw an error when the stage directory structure is missing", function() {
-			var options = {'draft': true};
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readdir = function(filename, cb) {
 				cb(new Error('readdir Error'));
@@ -87,7 +122,7 @@ describe("Publishes packages to GitHub Releases", function() {
 		});
 		
 		it("should throw an error when there are no files found within the stage directory", function() {
-			var options = {'draft': true};
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readdir = function(filename, cb) {
 				cb(null,[]);
@@ -96,7 +131,7 @@ describe("Publishes packages to GitHub Releases", function() {
 		});
 		
 		it("should throw an error when a staged file already exists in the current release", function() {
-			var options = {'draft': true};
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readdir = function(filename, cb) {
 				cb(null,["filename"]);
@@ -108,7 +143,7 @@ describe("Publishes packages to GitHub Releases", function() {
 		});
 		
 		it("should throw an error when github.releases.uploadAsset returns an error", function() {
-			var options = {'draft': true};
+			var options = {'draft': true, 'verbose': false};
 			reset_mocks();
 			fs.readdir = function(filename, cb) {
 				cb(null,["filename"]);
@@ -119,11 +154,19 @@ describe("Publishes packages to GitHub Releases", function() {
 			expect(function(){ index.publish(options); }).to.throw("uploadAsset error");
 		});
 		
-		it("should publish without an error", function() {
-			var options = {'draft': true};
+	});
+	
+	describe("Verify backwords compatible with any breaking changes made within the same MINOR version.", function() {
+	
+		it("should publish even when package.json's binary.remote_path property is not provided and instead the version is hard coded within binary.host", function() {
+			var options = {'draft': false, 'verbose': false};
 			reset_mocks();
+			fs.readFileSync = function(){return '{"name":"test","version":"0.0.1","repository": {"url":"git+https://github.com/test/test.git"},"binary":{"host":"https://github.com/test/test/releases/download/0.0.1"}}';};
 			fs.readdir = function(filename, cb) {
 				cb(null,["filename"]);
+			};
+			index.github.releases.createRelease = function(options, cb){
+				cb(null,{"tag_name":"0.0.1","draft":false,"assets":[{}]});
 			};
 			expect(function(){ index.publish(options); }).to.not.throw();
 		});


### PR DESCRIPTION
**Changes:**
* new ```--silent``` option to turn off verbose logging
* only options with a default value defined within ```NodePreGypGithub.prototype.createRelease``` are passed to the first parameter of ```github.releases.createRelease()```. When I introduced the silent flag I didn't feel it made sense that this property should automatically make it's way to ```github.releases.createRelease``` function. This prevents that.
* 100% test coverage, including a backwards compatibility section.
* running tests no longer includes the verbose messages that get generate from within the module
* coveralls badge now on README.md
* package.json's ```scripts.coverage``` now includes a command to post to coveralls when the COVERALLS_SERVICE_NAME and COVERALLS_REPO_TOKEN environment variables are defined properly.
* coveralls added as a ```devDependencies``` within package.json