### PR TITLE
Support Github Enterprise, upgrade Github client package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "releases"
   ],
   "dependencies": {
-    "github": "^0.2.4",
-    "commander": "^2.9.0"
+    "@octokit/rest": "^15.9.5",
+    "commander": "^2.9.0",
+    "mime-types": "^2.1.19",
+    "sinon": "^6.1.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
@octokit/rest is the new (since January) NPM package for accessing the Github API. There are some differences that are taken care of here.

One of them is setting the mime type on asset upload.

Since octokit initialization happens on init (instead of module execution), I've hacked up a means using Sinon for mocking it.

The primary result of this change is to allow for publishing to Github Enterprise instances.