### PR TITLE
Issue: api prefix breaks tar install

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,9 @@ NodePreGypGithub.prototype.uploadAsset = function(cfg){
 		id: this.release.id,
 		repo: this.repo,
 		name: cfg.fileName,
-		file: cfg.filePath,
-    contentType: mime.contentType(cfg.fileName) || 'application/octet-stream',
-    contentLength: fs.statSync(cfg.filePath).size,
+		file: fs.createReadStream(cfg.filePath),
+        contentType: mime.contentType(cfg.fileName) || 'application/octet-stream',
+        contentLength: fs.statSync(cfg.filePath).size
 	}, function(err){
 		if(err) throw err;
 		consoleLog('Staged file ' + cfg.fileName + ' saved to ' + this.owner + '/' +  this.repo + ' release ' + this.release.tag_name + ' successfully.');

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ NodePreGypGithub.prototype.init = function() {
 	if(!this.package_json.binary || 'object' !== typeof this.package_json.binary || 'string' !== typeof this.package_json.binary.host){
 		throw new Error('Missing binary.host in package.json');
 	}
-	else if (this.package_json.binary.host.substr(0, hostPrefix.length) !== hostPrefix){
+	else if (this.package_json.binary.host.replace('https://','https://api.').substr(0, hostPrefix.length) !== hostPrefix){
 		throw new Error('binary.host in package.json should begin with: "' + hostPrefix + '"');
 	}
 


### PR DESCRIPTION
- Fixed binary.host requiring api prefix so that node-pre-gyp installs tar correctly