### PR TITLE
Fix command `publish`, add storing of options as properties

### DIFF
--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -5,6 +5,7 @@ const program = require('commander');
 
 program
     .command('publish')
+    .storeOptionsAsProperties()
     .description('publishes the contents of .\\build\\stage\\{version} to the current version\'s GitHub release')
     .option("-r, --release", "publish immediately, do not create draft")
     .option("-s, --silent", "turns verbose messages off")


### PR DESCRIPTION
The command does not parse options correctly. 
Actually, it reads no options.

The official documentation of module [comander.js](https://github.com/tj/commander.js) says that to parse options as properties [the call `  .storeOptionsAsProperties()` is required](https://github.com/tj/commander.js#legacy-options-as-properties)

Also, at least one way more exists to fix the behavior. See the second example https://github.com/tj/commander.js#action-handler.