### PR TITLE
Fix options infocation

### DIFF
--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -9,7 +9,7 @@ program
     .description('publishes the contents of .\\build\\stage\\{version} to the current version\'s GitHub release')
     .option("-r, --release", "publish immediately, do not create draft")
     .option("-s, --silent", "turns verbose messages off")
-    .action(async function(cmd, options){
+    .action(async function(options){
         const opts = {
             draft: options.release ? false : true,
             verbose: options.silent ? false : true


### PR DESCRIPTION
Hi There.

Thanks for this incredibly useful action! But I believe I found a flaw: I was unable to get the `--release` switch to work.

After checking the [commander](https://www.npmjs.com/package/commander#action-handler) documentation and after experimenting in practice, it seems that the `--release` and `--silent` options are effectively ignored, due to the signature of the commander action handler being incorrect. I have removed the first `cmd` parameter, which I think should only be there if there was an actual argument expected. With no argument, the first parameter in the action handler should be `options`. This fixes the observed issue of not being able to create non-draft releases.

I have had a look at your tests and I can't see any that would fail due to `--release` or `--silent` not being handled, so I think this may have been an issue for a while.

Hope this helps.
