### PR TITLE
Add --commitish option to specify target_commitish branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Instead of ```node-pre-gyp publish``` use **```node-pre-gyp-github publish```**
 
 * --silent : Turns verbose messages off.
 * --release : Publish the GitHub Release immediately instead of creating a Draft.
-
   For Ex. ```node-pre-gyp-github publish --release```
+* --commitish : Defines the branch to be used for the target_commitish parameter. Defaults to 'master' if omitted.
+  For Ex. ```node-pre-gyp-github publish --commitish main ```
+
+
 
 ## Install
 

--- a/bin/node-pre-gyp-github.js
+++ b/bin/node-pre-gyp-github.js
@@ -8,10 +8,12 @@ program
   .description("publishes the contents of ./build/stage/{version} to the current version's GitHub release")
   .option("-r, --release", "publish immediately, do not create draft")
   .option("-s, --silent", "turns verbose messages off")
+  .option("-c, --commitish <branch>", "specify the branch for target_commitish, defaults to 'master'")
   .action(async (options) => {
     const opts = {
       draft: !options.release,
       verbose: !options.silent,
+      commitish: options.commitish || 'master'
     };
     try {
       const nodePreGypGithub = new NodePreGypGithub();

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = class NodePreGypGithub {
             owner: this.owner,
             repo: this.repo,
             tag_name: this.package_json.version,
-            target_commitish: 'master',
+            target_commitish: args.commitish,
             name: 'v' + this.package_json.version,
             body: this.package_json.name + ' ' + this.package_json.version,
             draft: true,


### PR DESCRIPTION
### Problem
The `target_commitish` parameter is hardcoded to 'master', causing issues when the default branch is different.

### Solution
- Added a `--commitish` option to allow users to specify the branch for the `target_commitish` parameter.
- If the `--commitish` option is not provided, it defaults to 'master'.

### Changes Made
- Updated the publish command to include the `--commitish` option.
- Modified the logic to use the value provided by `--commitish` or default to 'master'.

### Testing
- Tested with repositories having different default branches.
- Verified that the `--commitish` option correctly sets the `target_commitish` parameter.
- Ensured that the tool defaults to 'master' if the `--commitish` option is not provided.

### Usage
```bash
node-pre-gyp-github publish --release --commitish main
or 
node-pre-gyp-github publish  --commitish main
